### PR TITLE
Make the V1 Reader Empty Value Aware

### DIFF
--- a/src/main/java/net/fabricmc/lorenztiny/TinyMappingsReader.java
+++ b/src/main/java/net/fabricmc/lorenztiny/TinyMappingsReader.java
@@ -73,7 +73,7 @@ public class TinyMappingsReader extends MappingsReader {
 	public MappingSet read(final MappingSet mappings) {
 		for (final MappingTree.ClassMapping klass : this.tree.getClasses()) {
 			final String className = klass.getName(this.to);
-			if (className != null) {
+			if (className == null) {
 				continue;
 			}
 			final ClassMapping<?, ?> mapping = mappings.getOrCreateClassMapping(klass.getName(this.from))

--- a/src/main/java/net/fabricmc/lorenztiny/TinyMappingsReader.java
+++ b/src/main/java/net/fabricmc/lorenztiny/TinyMappingsReader.java
@@ -72,22 +72,32 @@ public class TinyMappingsReader extends MappingsReader {
 	@Override
 	public MappingSet read(final MappingSet mappings) {
 		for (final MappingTree.ClassMapping klass : this.tree.getClasses()) {
+			final String className = klass.getName(this.to);
+			if (className.isEmpty()) {
+				continue;
+			}
 			final ClassMapping<?, ?> mapping = mappings.getOrCreateClassMapping(klass.getName(this.from))
-					.setDeobfuscatedName(klass.getName(this.to));
+					.setDeobfuscatedName(className);
 
 			for (final MappingTree.FieldMapping field : klass.getFields()) {
-				mapping.getOrCreateFieldMapping(field.getName(this.from), field.getDesc(this.from))
-						.setDeobfuscatedName(field.getName(this.to));
+				final String fieldName = field.getName(this.to);
+				if (!fieldName.isEmpty()) {
+					mapping.getOrCreateFieldMapping(field.getName(this.from), field.getDesc(this.from))
+							.setDeobfuscatedName(fieldName);
+				}
 			}
 
 			for (final MappingTree.MethodMapping method : klass.getMethods()) {
-				final MethodMapping methodmapping = mapping
-						.getOrCreateMethodMapping(method.getName(this.from), method.getDesc(this.from))
-						.setDeobfuscatedName(method.getName(this.to));
+				final String methodName = method.getName(this.to);
+				if (!methodName.isEmpty()) {
+					final MethodMapping methodmapping = mapping
+							.getOrCreateMethodMapping(method.getName(this.from), method.getDesc(this.from))
+							.setDeobfuscatedName(methodName);
 
-				for (final MappingTree.MethodArgMapping param : method.getArgs()) {
-					methodmapping.getOrCreateParameterMapping(param.getArgPosition())
-							.setDeobfuscatedName(param.getName(this.to));
+					for (final MappingTree.MethodArgMapping param : method.getArgs()) {
+						methodmapping.getOrCreateParameterMapping(param.getArgPosition())
+								.setDeobfuscatedName(param.getName(this.to));
+					}
 				}
 			}
 		}

--- a/src/main/java/net/fabricmc/lorenztiny/TinyMappingsReader.java
+++ b/src/main/java/net/fabricmc/lorenztiny/TinyMappingsReader.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of lorenz-tiny, licensed under the MIT License (MIT).
  *
- * Copyright (c) 2020 FabricMC
+ * Copyright (c) 2020, 2022 FabricMC
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/net/fabricmc/lorenztiny/TinyMappingsReader.java
+++ b/src/main/java/net/fabricmc/lorenztiny/TinyMappingsReader.java
@@ -73,7 +73,7 @@ public class TinyMappingsReader extends MappingsReader {
 	public MappingSet read(final MappingSet mappings) {
 		for (final MappingTree.ClassMapping klass : this.tree.getClasses()) {
 			final String className = klass.getName(this.to);
-			if (className.isEmpty()) {
+			if (className != null) {
 				continue;
 			}
 			final ClassMapping<?, ?> mapping = mappings.getOrCreateClassMapping(klass.getName(this.from))
@@ -81,7 +81,7 @@ public class TinyMappingsReader extends MappingsReader {
 
 			for (final MappingTree.FieldMapping field : klass.getFields()) {
 				final String fieldName = field.getName(this.to);
-				if (!fieldName.isEmpty()) {
+				if (fieldName != null) {
 					mapping.getOrCreateFieldMapping(field.getName(this.from), field.getDesc(this.from))
 							.setDeobfuscatedName(fieldName);
 				}
@@ -89,7 +89,7 @@ public class TinyMappingsReader extends MappingsReader {
 
 			for (final MappingTree.MethodMapping method : klass.getMethods()) {
 				final String methodName = method.getName(this.to);
-				if (!methodName.isEmpty()) {
+				if (methodName != null) {
 					final MethodMapping methodmapping = mapping
 							.getOrCreateMethodMapping(method.getName(this.from), method.getDesc(this.from))
 							.setDeobfuscatedName(methodName);

--- a/src/main/java/net/fabricmc/lorenztiny/TinyMappingsReader.java
+++ b/src/main/java/net/fabricmc/lorenztiny/TinyMappingsReader.java
@@ -72,27 +72,30 @@ public class TinyMappingsReader extends MappingsReader {
 	@Override
 	public MappingSet read(final MappingSet mappings) {
 		for (final MappingTree.ClassMapping klass : this.tree.getClasses()) {
-			final String className = klass.getName(this.to);
-			if (className == null) {
+			final String classNameTo = klass.getName(this.to);
+			final String classNameFrom = klass.getName(this.from);
+			if (classNameTo == null || classNameFrom == null) {
 				continue;
 			}
-			final ClassMapping<?, ?> mapping = mappings.getOrCreateClassMapping(klass.getName(this.from))
-					.setDeobfuscatedName(className);
+			final ClassMapping<?, ?> mapping = mappings.getOrCreateClassMapping(classNameFrom)
+					.setDeobfuscatedName(classNameTo);
 
 			for (final MappingTree.FieldMapping field : klass.getFields()) {
-				final String fieldName = field.getName(this.to);
-				if (fieldName != null) {
-					mapping.getOrCreateFieldMapping(field.getName(this.from), field.getDesc(this.from))
-							.setDeobfuscatedName(fieldName);
+				final String fieldNameTo = field.getName(this.to);
+				final String fieldNameFrom = field.getName(this.from);
+				if (fieldNameTo != null) {
+					mapping.getOrCreateFieldMapping(fieldNameFrom, field.getDesc(this.from))
+							.setDeobfuscatedName(fieldNameTo);
 				}
 			}
 
 			for (final MappingTree.MethodMapping method : klass.getMethods()) {
-				final String methodName = method.getName(this.to);
-				if (methodName != null) {
+				final String methodNameTo = method.getName(this.to);
+				final String methodNameFrom = method.getName(this.from);
+				if (methodNameTo != null) {
 					final MethodMapping methodmapping = mapping
-							.getOrCreateMethodMapping(method.getName(this.from), method.getDesc(this.from))
-							.setDeobfuscatedName(methodName);
+							.getOrCreateMethodMapping(methodNameFrom, method.getDesc(this.from))
+							.setDeobfuscatedName(methodNameTo);
 
 					for (final MappingTree.MethodArgMapping param : method.getArgs()) {
 						methodmapping.getOrCreateParameterMapping(param.getArgPosition())


### PR DESCRIPTION
Fixes errors related to the target name being empty, and should fix support for v1 mappings with empty values. 
Continuation of https://github.com/FabricMC/tiny-remapper/pull/85